### PR TITLE
remove space between ")" and "," when using ArrayNested filter

### DIFF
--- a/Beautifier/Filter/ArrayNested.filter.php
+++ b/Beautifier/Filter/ArrayNested.filter.php
@@ -98,6 +98,7 @@ class PHP_Beautifier_Filter_ArrayNested extends PHP_Beautifier_Filter
      */
     public function t_comma($sTag) 
     {
+        $this->oBeaut->removeWhitespace();
         if ($this->oBeaut->getControlParenthesis() != T_ARRAY) {
             $this->oBeaut->add($sTag . ' ');
         } else {

--- a/tests/Beautifier/Filter/arraynested_sample_file.phps
+++ b/tests/Beautifier/Filter/arraynested_sample_file.phps
@@ -6,13 +6,13 @@ array(
         1,
         2,
         3
-    ) ,
-    'function_result' => sprintf("Function result", "Function result") ,
+    ),
+    'function_result' => sprintf("Function result", "Function result"),
     'example_array' => array(
         1,
         2,
         3
-    ) ,
+    ),
     'example' => null,
 );
 ?>


### PR DESCRIPTION
I'm assuming the space before the comma after an array when using the ArrayNested filter is unintentional. This patch gets rid of it.
