### PR TITLE
remove echo in middle of BeautifierBugsTest.php

### DIFF
--- a/tests/BeautifierBugsTest.php
+++ b/tests/BeautifierBugsTest.php
@@ -1264,7 +1264,6 @@ function showno(\$no) {
 echo showno(rand(0, 100));
 ?>
 SCRIPT;
-echo $this->oBeaut->get();
 $this->assertEquals($sExpected, $this->oBeaut->get());
     }
     


### PR DESCRIPTION
There's a leftover echo in the middle of testBug14575(), so code is spit out in the middle of the test results. This just deletes that line.
