### PR TITLE
add spaces after semicolons inside parens after "for"

### DIFF
--- a/Beautifier/Filter/Default.filter.php
+++ b/Beautifier/Filter/Default.filter.php
@@ -279,7 +279,9 @@ final class PHP_Beautifier_Filter_Default extends PHP_Beautifier_Filter
     {
         $this->oBeaut->removeWhitespace();
         $this->oBeaut->add($sTag);
-        if ($this->oBeaut->getControlParenthesis() != T_FOR) {
+        if ($this->oBeaut->getControlParenthesis() == T_FOR) {
+            $this->oBeaut->add(' ');
+        } else {
             $this->oBeaut->addNewLineIndent();
         }
     }

--- a/tests/BeautifierTest.php
+++ b/tests/BeautifierTest.php
@@ -281,6 +281,26 @@ SCRIPT;
         $this->assertEquals($sTextExpected,$this->oBeaut->get());            
     
     }
+    function testForSpacing() {
+        $sTextOriginal = <<<SCRIPT
+<?php
+for(\$i=0;\$i<5;\$i++){print"\$i\n";for(\$j=0;\$j<5;\$j++){print"\$j\n";}}
+?>
+SCRIPT;
+        $sTextExpected = <<<SCRIPT
+<?php
+for (\$i = 0; \$i < 5; \$i++) {
+    print "\$i\n";
+    for (\$j = 0; \$j < 5; \$j++) {
+        print "\$j\n";
+    }
+}
+?>
+SCRIPT;
+        $this->oBeaut->setInputString($sTextOriginal);
+        $this->oBeaut->process();
+        $this->assertEquals($sTextExpected,$this->oBeaut->get());
+    }
     /*
     function testresetProperties() {
     }


### PR DESCRIPTION
Normally if there are spaces around operators there are also spaces after the semicolons in a `for`:

```
for ($i = 0; $i < 5; $i++) {
```

This adds them and includes a test.
