### PR TITLE
skip DocBlock test since it's broken

### DIFF
--- a/tests/Beautifier/Filter/DocBlockTest.php
+++ b/tests/Beautifier/Filter/DocBlockTest.php
@@ -34,6 +34,10 @@ class DocBlockTest extends PHPUnit_Framework_TestCase
      */
     function testDocBlockSample() 
     {
+        $this->markTestSkipped(
+            "PHP_DocBlockGenerator has changed its alignment algorithm.\n" .
+            "See http://pear.php.net/bugs/bug.php?id=16193"
+        );
         $sSample = dirname(__FILE__) . '/docblock_sample_file.phps';
         $sContent = file_get_contents($sSample);
         $this->oBeaut->setInputFile($sSample);


### PR DESCRIPTION
PHP_DocBlockGenerator has changed its alignment algorithm, and I'm not
sure it makes sense.  See http://pear.php.net/bugs/bug.php?id=16193
