### PR TITLE
Fix IndentStyles so open brace after object operator isn't treated as start of a block

### DIFF
--- a/Beautifier/Filter/IndentStyles.filter.php
+++ b/Beautifier/Filter/IndentStyles.filter.php
@@ -153,13 +153,18 @@ class PHP_Beautifier_Filter_IndentStyles extends PHP_Beautifier_Filter
      */
     function t_open_brace_bsd($sTag) 
     {
-        $this->oBeaut->addNewLineIndent();
-        $this->oBeaut->add($sTag);
-        if ($this->oBeaut->getControlSeq() == T_SWITCH) {
+        if ($this->oBeaut->openBraceDontProcess()) {
+            $this->oBeaut->add($sTag);
+        } else {
+            $this->oBeaut->removeWhitespace();
+            $this->oBeaut->addNewLineIndent();
+            $this->oBeaut->add($sTag);
+            if ($this->oBeaut->getControlSeq() == T_SWITCH) {
+                $this->oBeaut->incIndent();
+            }
             $this->oBeaut->incIndent();
+            $this->oBeaut->addNewLineIndent();
         }
-        $this->oBeaut->incIndent();
-        $this->oBeaut->addNewLineIndent();
     }
     /**
      * t_close_brace_bsd: Close braces in BSD style
@@ -194,11 +199,16 @@ class PHP_Beautifier_Filter_IndentStyles extends PHP_Beautifier_Filter
      */
     function t_open_brace_ws($sTag) 
     {
-        $this->oBeaut->addNewLine();
-        $this->oBeaut->incIndent();
-        $this->oBeaut->addIndent();
-        $this->oBeaut->add($sTag);
-        $this->oBeaut->addNewLineIndent();
+        if ($this->oBeaut->openBraceDontProcess()) {
+            $this->oBeaut->add($sTag);
+        } else {
+            $this->oBeaut->removeWhitespace();
+            $this->oBeaut->addNewLine();
+            $this->oBeaut->incIndent();
+            $this->oBeaut->addIndent();
+            $this->oBeaut->add($sTag);
+            $this->oBeaut->addNewLineIndent();
+        }
     }
     /**
      * t_close_brace_ws: Close braces in Whitesmiths style
@@ -252,12 +262,17 @@ class PHP_Beautifier_Filter_IndentStyles extends PHP_Beautifier_Filter
      */
     function t_open_brace_gnu($sTag) 
     {
-        $iHalfSpace = floor($this->oBeaut->iIndentNumber/2);
-        $this->oBeaut->addNewLineIndent();
-        $this->oBeaut->add(str_repeat($this->oBeaut->sIndentChar, $iHalfSpace));
-        $this->oBeaut->add($sTag);
-        $this->oBeaut->incIndent();
-        $this->oBeaut->addNewLineIndent();
+        if ($this->oBeaut->openBraceDontProcess()) {
+            $this->oBeaut->add($sTag);
+        } else {
+            $this->oBeaut->removeWhitespace();
+            $iHalfSpace = floor($this->oBeaut->iIndentNumber/2);
+            $this->oBeaut->addNewLineIndent();
+            $this->oBeaut->add(str_repeat($this->oBeaut->sIndentChar, $iHalfSpace));
+            $this->oBeaut->add($sTag);
+            $this->oBeaut->incIndent();
+            $this->oBeaut->addNewLineIndent();
+        }
     }
     /**
      * t_else: Else for bds, gnu & ws

--- a/tests/Beautifier/Filter/indentstyles_bsd_sample_file.phps
+++ b/tests/Beautifier/Filter/indentstyles_bsd_sample_file.phps
@@ -1,8 +1,20 @@
 <?php
-if ($x == 1) 
+if ($x == 1)
 {
     $x = "Any text with {$x} sign";
 }
+elseif ($x == 2)
+{
+    $x = "Any text with ${x} sign";
+}
+else
+{
+    $x = $object->{$property};
+}
 if ($x == 1) $x = 2;
 else $x = 3;
+while ($i++ < 4)
+{
+    $obj->{'set' . $prop}($i);
+}
 ?>

--- a/tests/Beautifier/Filter/indentstyles_gnu_sample_file.phps
+++ b/tests/Beautifier/Filter/indentstyles_gnu_sample_file.phps
@@ -1,6 +1,20 @@
 <?php
-if ($x == 1) 
+if ($x == 1)
   {
     $x = "Any text with {$x} sign";
+  }
+elseif ($x == 2)
+  {
+    $x = "Any text with ${x} sign";
+  }
+else
+  {
+    $x = $object->{$property};
+  }
+if ($x == 1) $x = 2;
+else $x = 3;
+while ($i++ < 4)
+  {
+    $obj->{'set' . $prop}($i);
   }
 ?>

--- a/tests/Beautifier/Filter/indentstyles_kr_sample_file.phps
+++ b/tests/Beautifier/Filter/indentstyles_kr_sample_file.phps
@@ -2,4 +2,15 @@
 if ($x == 1) {
     $x = "Any text with {$x} sign";
 }
+elseif ($x == 2) {
+    $x = "Any text with ${x} sign";
+}
+else {
+    $x = $object->{$property};
+}
+if ($x == 1) $x = 2;
+else $x = 3;
+while ($i++ < 4) {
+    $obj->{'set' . $prop}($i);
+}
 ?>

--- a/tests/Beautifier/Filter/indentstyles_ws_sample_file.phps
+++ b/tests/Beautifier/Filter/indentstyles_ws_sample_file.phps
@@ -1,6 +1,20 @@
 <?php
-if ($x == 1) 
+if ($x == 1)
     {
     $x = "Any text with {$x} sign";
+    }
+elseif ($x == 2)
+    {
+    $x = "Any text with ${x} sign";
+    }
+else
+    {
+    $x = $object->{$property};
+    }
+if ($x == 1) $x = 2;
+else $x = 3;
+while ($i++ < 4)
+    {
+    $obj->{'set' . $prop}($i);
     }
 ?>


### PR DESCRIPTION
The `t_open_brace` methods for the indent styles need to use `openBraceDontProcess` the way the default `t_open_brace` does. Without that, the open brace in something like `$object->{$property}` gets treated as starting a block, and the formatting is trashed. See also http://pear.php.net/bugs/bug.php?id=17780

This also avoids end-of-line spaces after `if ()`, etc., in styles that put the open brace on a new line.
