### PR TITLE
Fix and addenda

### DIFF
--- a/Beautifier/Filter.php
+++ b/Beautifier/Filter.php
@@ -228,11 +228,12 @@ abstract class PHP_Beautifier_Filter
         }
         $sValue = $token[1];
         if ($sMethod) {
-            if ($this->oBeaut->iVerbose > 5) {
-                echo $sMethod . ":" . trim($sValue) . PHP_EOL;
-            }
+            PHP_Beautifier_Common::getLog()->log($this->getName()."->".$sMethod."(".trim($sValue).")", PEAR_LOG_DEBUG);
             // return false if PHP_Beautifier_Filter::BYPASS
-            return ($this->$sMethod($sValue) !== PHP_Beautifier_Filter::BYPASS);
+	    $result = ($this->$sMethod($sValue) !== PHP_Beautifier_Filter::BYPASS);
+	    if ($result)
+		PHP_Beautifier_Common::getLog()->log($this->getName()."->".$sMethod." done", PEAR_LOG_DEBUG);
+            return $result;
         } else { // WEIRD!!! -> Add the same received
             $this->oBeaut->add($token[1]);
             PHP_Beautifier_Common::getLog()->log("Add same received:" . trim($token[1]), PEAR_LOG_DEBUG);

--- a/Beautifier/Filter.php
+++ b/Beautifier/Filter.php
@@ -230,9 +230,9 @@ abstract class PHP_Beautifier_Filter
         if ($sMethod) {
             PHP_Beautifier_Common::getLog()->log($this->getName()."->".$sMethod."(".trim($sValue).")", PEAR_LOG_DEBUG);
             // return false if PHP_Beautifier_Filter::BYPASS
-	    $result = ($this->$sMethod($sValue) !== PHP_Beautifier_Filter::BYPASS);
-	    if ($result)
-		PHP_Beautifier_Common::getLog()->log($this->getName()."->".$sMethod." done", PEAR_LOG_DEBUG);
+            $result = ($this->$sMethod($sValue) !== PHP_Beautifier_Filter::BYPASS);
+            if ($result)
+                PHP_Beautifier_Common::getLog()->log($this->getName()."->".$sMethod." done", PEAR_LOG_DEBUG);
             return $result;
         } else { // WEIRD!!! -> Add the same received
             $this->oBeaut->add($token[1]);

--- a/Beautifier/Filter/Fluent.filter.php
+++ b/Beautifier/Filter/Fluent.filter.php
@@ -56,14 +56,37 @@ class PHP_Beautifier_Filter_Fluent extends PHP_Beautifier_Filter
     {
         $counter = 1;
         $next = $this->oBeaut->getToken($this->oBeaut->iCount + $counter);
-        while (($next[0] != T_OBJECT_OPERATOR) && ($next != ";")) {
+        $parenthesis = 0;
+        $brace = 0;
+        while ($next && ($parenthesis > 0 || $brace > 0 || $next[0] != T_OBJECT_OPERATOR)
+                     && ($next != ";" )) {
             $counter++;
+            switch ($next) {
+              case '(' : $parenthesis += 1; break;
+              case ')' : $parenthesis -= 1; break;
+              case '[' : $brace += 1; break;
+              case ']' : $brace -= 1; break;            
+            }
+            if ($parenthesis <= 0 && $brace == 0 && !in_array($next[0],
+                  array(T_VARIABLE,T_PAAMAYIM_NEKUDOTAYIM,T_WHITESPACE,T_DOUBLE_COLON,T_STRING)))
+              break;
             $next = $this->oBeaut->getToken($this->oBeaut->iCount + $counter);
         }
         $counter = 1;
         $prev = $this->oBeaut->getToken($this->oBeaut->iCount - $counter);
-        while (($prev[0] != T_OBJECT_OPERATOR) && ($prev[0] != T_VARIABLE)) {
+        $parenthesis = 0;
+        $brace = 0;
+        while ($prev && (($prev[0] != T_OBJECT_OPERATOR) && ($prev[0] != T_VARIABLE))) {
             $counter++;
+            switch ($next) {
+              case '(' : $parenthesis += 1; break;
+              case ')' : $parenthesis -= 1; break;
+              case '[' : $brace += 1; break;
+              case ']' : $brace -= 1; break;
+            }
+            if ($parenthesis >= 0 && $brace == 0 && !in_array($next[0],
+                  array(T_PAAMAYIM_NEKUDOTAYIM,T_WHITESPACE,T_DOUBLE_COLON,T_STRING)))
+              break;
             $prev = $this->oBeaut->getToken($this->oBeaut->iCount - $counter);
         }
         $this->oBeaut->removeWhiteSpace();

--- a/Beautifier/Filter/NewLines.filter.php
+++ b/Beautifier/Filter/NewLines.filter.php
@@ -110,5 +110,28 @@ class PHP_Beautifier_Filter_NewLines extends PHP_Beautifier_Filter
         }
         return PHP_Beautifier_Filter::BYPASS;
     }
+
+    /**
+     * Called from {@link PHP_Beautifier::process()} at the end of processing
+     * The post-process must be made in {@link PHP_Beautifier::$aOut}
+     *
+     * @access public
+     * @return void
+     */
+    public function postProcess()
+    {
+        foreach ($this->oBeaut->aOut as $i => &$out)
+        {
+            if (is_string($out) && $out != '' && trim($out) == '')
+            {
+                $trimed = trim($out, $this->oBeaut->getIndentChar());
+                if ($trimed != $out && strpos($this->oBeaut->aOut[$i-1],"\n") !== false
+                                    && strpos($this->oBeaut->aOut[$i+1],"\n") !== false )
+                {
+                    $out = $trimed; 
+                }
+            }
+        }
+    }
 }
 ?>

--- a/scripts/php_beautifier
+++ b/scripts/php_beautifier
@@ -65,7 +65,7 @@
     $bRecursive = false;
     $sCompress = false;
     $aFiltersDirectory = array();
-	$iVerbose=PEAR_LOG_WARNING;
+    $iVerbose=PEAR_LOG_WARNING;
     //end default_options
     $argv = Console_Getopt::readPHPArgv();
     $aLongOptions = array(
@@ -79,16 +79,16 @@
         'recursive',
         'help',
         'compress==',
-		'verbose'
+	'verbose'
     );
-    $options = Console_Getopt::getopt($argv, "f:o:d:l:t::s::c::r?hv", $aLongOptions);
+    $options = Console_Getopt::getopt($argv, "f:o:d:l:t::s::c::v::r?h", $aLongOptions);
     if (PEAR::isError($options)) {
         usage($options);
     }
     foreach($options[0] as $opt) {
         $sArgument = str_replace('-', '', $opt[0]);
         $sParam = $opt[1];
-        $oLog->log("Arg: ".$sArgument."[$sParam]", PEAR_LOG_DEBUG);
+        $oLog->log("Arg: ".$sArgument."[$sParam]", 6);
         switch ($sArgument) {
             case 'input':
             case 'f':
@@ -158,10 +158,10 @@
             case 'version':
                 version();
             break;
-			case 'v':
-			case 'verbose':
-				$iVerbose=PEAR_LOG_INFO;
-			break;
+            case 'v':
+            case 'verbose':
+                $iVerbose = ($sParam) ? (int) $sParam : PEAR_LOG_INFO;
+            break;
         }
     }
 	// add the console logger


### PR DESCRIPTION
- Add value for verbose parameter in command line script 
- Use log in Filter.php instead of echo
- Fix Fluent filter, because it didn't work on code like this 

```
if ($this->method()->method2() == $test)
```
- Remove trailing whitespace on empty lines created with NewLines filter
