### PR TITLE
New filters: KeepEmptyLines, BreakLongLists, SpaceOpAssignments

### DIFF
--- a/Beautifier/Filter/BreakLongLists.filter.php
+++ b/Beautifier/Filter/BreakLongLists.filter.php
@@ -96,8 +96,8 @@ class PHP_Beautifier_Filter_BreakLongLists extends PHP_Beautifier_Filter
      */
     public function t_parenthesis_open($sTag)
     {
+        $this->oBeaut->add($sTag);
         if ($this->in_scope()) {
-            $this->oBeaut->add($sTag);
             $this->oBeaut->addNewLine();
             $this->oBeaut->incIndent();
             $this->oBeaut->addIndent();

--- a/Beautifier/Filter/KeepEmptyLines.filter.php
+++ b/Beautifier/Filter/KeepEmptyLines.filter.php
@@ -37,13 +37,17 @@
 class PHP_Beautifier_Filter_KeepEmptyLines extends PHP_Beautifier_Filter
 {
     protected $sDescription = 'Keep a single empty line where empty lines can be found';
+    public function __construct(PHP_Beautifier $oBeaut, $aSettings = array())
+    {
+        parent::__construct($oBeaut, $aSettings);
+        $this->oBeaut->setNoDeletePreviousSpaceHack();
+    }
     public function t_whitespace($sTag)
     {
         if (preg_match('/\n\s*\r?\n/', $sTag)) {
-            // The indent has already been added
-            $new = $this->oBeaut->aOut[count($this->oBeaut->aOut) - 1];
-            $new = "\n" . $new;
-            $this->oBeaut->aOut[count($this->oBeaut->aOut) - 1] = $new;
+            $this->oBeaut->removeWhitespace();
+            $this->oBeaut->aOut[count($this->oBeaut->aOut) - 1].= "\n/**ndps**/\n"; // see setNoDeletePreviousSpaceHack
+            $this->oBeaut->addIndent();
         }
     }
 }

--- a/Beautifier/Filter/KeepEmptyLines.filter.php
+++ b/Beautifier/Filter/KeepEmptyLines.filter.php
@@ -1,0 +1,50 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+/**
+ * Keep a single empty line where empty lines can be found
+ *
+ * PHP version 5
+ *
+ * LICENSE: This source file is subject to version 3.0 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_0.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   PHP
+ * @package    PHP_Beautifier
+ * @subpackage Filter
+ * @author     Elod Csirmaz <https://github.com/csirmaz>
+ * @copyright  2014 Elod Csirmaz
+ * @license    http://www.php.net/license/3_0.txt  PHP License 3.0
+ * @version    1.0
+ * @link       http://pear.php.net/package/PHP_Beautifier
+ * @link       http://beautifyphp.sourceforge.net
+ */
+/**
+ * Keep a single empty line where empty lines can be found
+ *
+ * @category   PHP
+ * @package    PHP_Beautifier
+ * @subpackage Filter
+ * @author     Elod Csirmaz <https://github.com/csirmaz>
+ * @copyright  2014 Elod Csirmaz, based on ArrayNested by Claudio Bustos
+ * @license    http://www.php.net/license/3_0.txt  PHP License 3.0
+ * @version    1.0
+ * @link       http://pear.php.net/package/PHP_Beautifier
+ * @link       http://beautifyphp.sourceforge.net
+ */
+class PHP_Beautifier_Filter_KeepEmptyLines extends PHP_Beautifier_Filter
+{
+    protected $sDescription = 'Keep a single empty line where empty lines can be found';
+    public function t_whitespace($sTag)
+    {
+        if (preg_match('/\n\s*\r?\n/', $sTag)) {
+            // The indent has already been added
+            $new = $this->oBeaut->aOut[count($this->oBeaut->aOut) - 1];
+            $new = "\n" . $new;
+            $this->oBeaut->aOut[count($this->oBeaut->aOut) - 1] = $new;
+        }
+    }
+}
+?>

--- a/Beautifier/Filter/KeepEmptyLines.filter.php
+++ b/Beautifier/Filter/KeepEmptyLines.filter.php
@@ -28,7 +28,7 @@
  * @package    PHP_Beautifier
  * @subpackage Filter
  * @author     Elod Csirmaz <https://github.com/csirmaz>
- * @copyright  2014 Elod Csirmaz, based on ArrayNested by Claudio Bustos
+ * @copyright  2014 Elod Csirmaz
  * @license    http://www.php.net/license/3_0.txt  PHP License 3.0
  * @version    1.0
  * @link       http://pear.php.net/package/PHP_Beautifier

--- a/Beautifier/Filter/LongArrayNested.filter.php
+++ b/Beautifier/Filter/LongArrayNested.filter.php
@@ -1,0 +1,169 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+/**
+ * Filter Long Array Nested: Indent long array structures only
+ *
+ * PHP version 5
+ *
+ * LICENSE: This source file is subject to version 3.0 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_0.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   PHP
+ * @package    PHP_Beautifier
+ * @subpackage Filter
+ * @author     Elod Csirmaz <https://github.com/csirmaz>
+ * @copyright  2014 Elod Csirmaz, based on ArrayNested by Claudio Bustos
+ * @license    http://www.php.net/license/3_0.txt  PHP License 3.0
+ * @version    CVS: $Id:$
+ * @link       http://pear.php.net/package/PHP_Beautifier
+ * @link       http://beautifyphp.sourceforge.net
+ */
+/**
+ * Filter Long Array Nested: Indent long array structures only
+ *
+ * Break array()s into multiple lines that, on a single line, would be longer
+ * than a given limit. This limit defaults to 50, and can be specified using
+ * the 'maxlen' parameter:
+ *
+ * --filters="LongArrayNested(maxlen=20)"
+ *
+ * @category   PHP
+ * @package    PHP_Beautifier
+ * @subpackage Filter
+ * @author     Elod Csirmaz <https://github.com/csirmaz>
+ * @copyright  2014 Elod Csirmaz, based on ArrayNested by Claudio Bustos
+ * @license    http://www.php.net/license/3_0.txt  PHP License 3.0
+ * @version    CVS: $Id:$
+ * @link       http://pear.php.net/package/PHP_Beautifier
+ * @link       http://beautifyphp.sourceforge.net
+ */
+/**
+ * Based on:
+ * Filter Array Nested: Indent the array structures
+ * Ex.
+ * <CODE>
+ *    $aMyArray = array(
+ *        array(
+ *            array(
+ *                array(
+ *                    'el'=>1,
+ *                    'el'=>2
+ *                )
+ *            )
+ *        )
+ *    );
+ * </CODE>
+ *
+ * @category   PHP
+ * @package    PHP_Beautifier
+ * @subpackage Filter
+ * @author     Claudio Bustos <cdx@users.sourceforge.com>
+ * @copyright  2004-2010 Claudio Bustos
+ * @license    http://www.php.net/license/3_0.txt  PHP License 3.0
+ * @version    Release: @package_version@
+ * @link       http://pear.php.net/package/PHP_Beautifier
+ * @link       http://beautifyphp.sourceforge.net
+ */
+class PHP_Beautifier_Filter_LongArrayNested extends PHP_Beautifier_Filter
+{
+    protected $aSettings = array('maxlen' => '50');
+    var $stack = array();
+    protected $sDescription = 'Break array()s into multiple lines that, on a single line, would be longer than a given limit';
+    public function __construct(PHP_Beautifier $oBeaut, $aSettings = array())
+    {
+        parent::__construct($oBeaut, $aSettings);
+        $this->addSettingDefinition('maxlen', 'text', 'Break array()s into multiple lines above this length');
+    }
+    /**
+     * t_parenthesis_open
+     *
+     * @param mixed $sTag The tag to be procesed
+     *
+     * @access public
+     * @return void
+     */
+    public function t_parenthesis_open($sTag)
+    {
+        $this->oBeaut->add($sTag);
+        if ($this->oBeaut->getControlParenthesis() == T_ARRAY) {
+            $this->oBeaut->addNewLine();
+            $this->oBeaut->incIndent();
+            $this->oBeaut->addIndent();
+            array_push($this->stack, count($this->oBeaut->aOut));
+        }
+    }
+    /**
+     * t_parenthesis_close
+     *
+     * @param mixed $sTag The tag to be procesed
+     *
+     * @access public
+     * @return void
+     */
+    public function t_parenthesis_close($sTag)
+    {
+        $isShortArray = false;
+        if ($this->oBeaut->getControlParenthesis() == T_ARRAY) {
+            $begCount = array_pop($this->stack);
+            // Check how long the array is, without whitespace
+            $arraystr = '';
+            for ($i = $begCount; $i < count($this->oBeaut->aOut); $i++) {
+                $arraystr.= $this->oBeaut->aOut[$i];
+            }
+            $arraystr = preg_replace('/\s/', '', $arraystr);
+            // If it is too short, remove whitespace we added before.
+            // The aOut[] elements are:
+            //        -2: newline
+            //        -1: indent
+            // $begCount: FIRST ELEMENT
+            //        +1: comma
+            //        +2: newline
+            //        +3: indent
+            //        +4: SECOND ELEMENT
+            if (strlen($arraystr) < $this->aSettings['maxlen']) {
+                $isShortArray = true;
+                $begCount2 = $begCount - 2;
+                if ($begCount2 < 0) {
+                    $begCount2 = 0;
+                }
+                for ($i = $begCount2; $i < count($this->oBeaut->aOut); $i++) {
+                    $new = $this->oBeaut->aOut[$i];
+                    $new = preg_replace('/^\r?\n$/', '', $new);
+                    $new = preg_replace('/^[ \t]+$/', ($i < $begCount ? '' : ' '), $new);
+                    $this->oBeaut->aOut[$i] = $new;
+                }
+            }
+            $this->oBeaut->decIndent();
+            if ($this->oBeaut->getPreviousTokenContent() != '(' && !$isShortArray) {
+                $this->oBeaut->addNewLine();
+                $this->oBeaut->addIndent();
+            }
+            $this->oBeaut->add($sTag . ' ');
+        } else {
+            $this->oBeaut->add($sTag . ' ');
+        }
+    }
+    /**
+     * t_comma
+     *
+     * @param mixed $sTag The tag to be procesed
+     *
+     * @access public
+     * @return void
+     */
+    public function t_comma($sTag)
+    {
+        if ($this->oBeaut->getControlParenthesis() != T_ARRAY) {
+            $this->oBeaut->add($sTag . ' ');
+        } else {
+            $this->oBeaut->removeWhitespace();
+            $this->oBeaut->add($sTag);
+            $this->oBeaut->addNewLine();
+            $this->oBeaut->addIndent();
+        }
+    }
+}
+?>

--- a/Beautifier/Filter/SpaceOpAssignments.filter.php
+++ b/Beautifier/Filter/SpaceOpAssignments.filter.php
@@ -37,11 +37,6 @@
 class PHP_Beautifier_Filter_SpaceOpAssignments extends PHP_Beautifier_Filter
 {
     protected $sDescription = 'Add space before operator+assignments';
-    public function __construct(PHP_Beautifier $oBeaut, $aSettings = array())
-    {
-        parent::__construct($oBeaut, $aSettings);
-        $this->oBeaut->setNoDeletePreviousSpaceHack();
-    }
     /**
      * t_assigment_pre
      *

--- a/Beautifier/Filter/SpaceOpAssignments.filter.php
+++ b/Beautifier/Filter/SpaceOpAssignments.filter.php
@@ -1,0 +1,59 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4: */
+/**
+ * Add space before operator+assignments
+ *
+ * PHP version 5
+ *
+ * LICENSE: This source file is subject to version 3.0 of the PHP license
+ * that is available through the world-wide-web at the following URI:
+ * http://www.php.net/license/3_0.txt.  If you did not receive a copy of
+ * the PHP License and are unable to obtain it through the web, please
+ * send a note to license@php.net so we can mail you a copy immediately.
+ *
+ * @category   PHP
+ * @package    PHP_Beautifier
+ * @subpackage Filter
+ * @author     Elod Csirmaz <https://github.com/csirmaz>
+ * @copyright  2014 Elod Csirmaz
+ * @license    http://www.php.net/license/3_0.txt  PHP License 3.0
+ * @version    1.0
+ * @link       http://pear.php.net/package/PHP_Beautifier
+ * @link       http://beautifyphp.sourceforge.net
+ */
+/**
+ * Add space before operator+assignments
+ *
+ * @category   PHP
+ * @package    PHP_Beautifier
+ * @subpackage Filter
+ * @author     Elod Csirmaz <https://github.com/csirmaz>
+ * @copyright  2014 Elod Csirmaz
+ * @license    http://www.php.net/license/3_0.txt  PHP License 3.0
+ * @version    1.0
+ * @link       http://pear.php.net/package/PHP_Beautifier
+ * @link       http://beautifyphp.sourceforge.net
+ */
+class PHP_Beautifier_Filter_SpaceOpAssignments extends PHP_Beautifier_Filter
+{
+    protected $sDescription = 'Add space before operator+assignments';
+    public function __construct(PHP_Beautifier $oBeaut, $aSettings = array())
+    {
+        parent::__construct($oBeaut, $aSettings);
+        $this->oBeaut->setNoDeletePreviousSpaceHack();
+    }
+    /**
+     * t_assigment_pre
+     *
+     * @param mixed $sTag The tag to be processed
+     *
+     * @access public
+     * @return void
+     */
+    function t_assigment_pre($sTag)
+    {
+        $this->oBeaut->removeWhitespace();
+        $this->oBeaut->add(' ' . $sTag . ' ');
+    }
+}
+?>


### PR DESCRIPTION
Created three new filters:
- **BreakLongLists** breaks argument lists and arrays into multiple lines, but only if
  on a single line they would be too long.
- **KeepEmptyLines** keeps an empty line wherever one or more empty lines are encountered in the source.
- **SpaceOpAssignments** adds a single space before assignment operators that contain another operator like plus-equal or dot-equal.
